### PR TITLE
 Fixed buffer overflow on serial connection lost

### DIFF
--- a/SerialCom/QtRaspberry/serialworker.cpp
+++ b/SerialCom/QtRaspberry/serialworker.cpp
@@ -52,6 +52,7 @@ void SerialWorker::doWork()
     Frame *m_inFrame = nullptr;
     quint8 checksum = 0, xored = 0x00;
     int dataLength = 0;
+    int maxdataLength = 10;
 
     // Serial Port Initialization
     m_Serial = new QSerialPort();
@@ -83,7 +84,7 @@ void SerialWorker::doWork()
             {
                 QByteArray receivedData = m_Serial->readAll();
 
-                while(receivedData.count() > 0)
+                while(receivedData.count() > 0 && receivedData.count() < maxdataLength )
                 {
                     inByte = quint8(receivedData[0]);
                     receivedData.remove(0,1);


### PR DESCRIPTION
I was having continuous crashes due to buffer overflows caused by lack of synchronization on serial.... Or when the micro was sending data too fast. 
Setting a cap on the maximum length of the frame seems to tackle the issue... Maybe 10 bytes is too restrictive.

Maybe I am completely wrong in my explanation... But it seems to do the trick for me! Maybe this is not the best first app for a C++ and  Qt newie... anyhow, congrats on the app and the youtube tutorials!!