### PR TITLE
Auto reconnect serial device if serial is lost

### DIFF
--- a/SerialCom/QtRaspberry/serialworker.cpp
+++ b/SerialCom/QtRaspberry/serialworker.cpp
@@ -67,6 +67,19 @@ void SerialWorker::doWork()
 
     while(!abort)
     {
+
+        while (!m_Serial->isReadable() || (m_Serial->error() == QSerialPort::SerialPortError::ReadError)){
+            m_Serial->close();
+            QThread::sleep(1);
+            m_Serial->clearError();
+            //qDebug() << "SerialPort Status Wait: " << m_Serial->isReadable();
+            //qDebug() << "SerialPort Error Wait: " << m_Serial->error();
+            m_Serial->open(QIODevice::ReadWrite);
+            mutex.lock();
+            abort = _abort;
+            mutex.unlock();
+        }
+
         mutex.lock();
         abort = _abort;
         mutex.unlock();

--- a/SerialCom/QtRaspberry/serialworker.cpp
+++ b/SerialCom/QtRaspberry/serialworker.cpp
@@ -68,16 +68,23 @@ void SerialWorker::doWork()
     while(!abort)
     {
 
-        while (!m_Serial->isReadable() || (m_Serial->error() == QSerialPort::SerialPortError::ReadError)){
+        //qDebug() << "SerialPort Status Wait: " << m_Serial->error();
+        while (!m_Serial->isReadable() || (m_Serial->error() != QSerialPort::SerialPortError::NoError)){
+            if (m_Serial->error() == QSerialPort::SerialPortError::TimeoutError){
+                m_Serial->clearError();
+                //emit serialConnected(m_Serial->isReadable());
+                break;
+            }
             m_Serial->close();
             QThread::sleep(1);
             m_Serial->clearError();
-            //qDebug() << "SerialPort Status Wait: " << m_Serial->isReadable();
-            //qDebug() << "SerialPort Error Wait: " << m_Serial->error();
+            qDebug() << "SerialPort Error Wait: " << m_Serial->error();
+            qDebug() << "Is readable? Wait: " << m_Serial->isReadable();
             m_Serial->open(QIODevice::ReadWrite);
             mutex.lock();
-            abort = _abort;
+            abort = true;
             mutex.unlock();
+            emit serialConnected(m_Serial->isReadable());
         }
 
         mutex.lock();

--- a/SerialCom/QtRaspberry/serialworker.h
+++ b/SerialCom/QtRaspberry/serialworker.h
@@ -37,6 +37,7 @@ signals:
     void valueChanged(const QString &value);
     void finished();
     void frameReceived(Frame *frame);
+    void serialConnected(bool _value);
 
 public slots:
     void doWork();


### PR DESCRIPTION
Auto-reconnect serial in case of communication lost.  A singal should be also created to notify qml and GUI.

It sleeps for 1s waiting for the connection to be valid.

RPI4 CPU usage from 20%running to 1% IDLE (9 serial values being constantly read separated 20ms with a 100ms cycle pause)


Work in progress... Ideal solution still not found...