### PR TITLE
Prevent hung command parse in MCU incomming  buffer overflow case

### DIFF
--- a/SerialCom/ESP32/SerialCom.ino
+++ b/SerialCom/ESP32/SerialCom.ino
@@ -185,6 +185,10 @@ void loop()
                                 g_AdcEnabled = (bool)GetDataByte(g_InputBuffer);
                             }
                         }
+                    } else 
+                    {
+                        g_ReceiverStatus = RCV_ST_IDLE;
+                        break;
                     }
                 } break;
             }


### PR DESCRIPTION
When the Arduino/ESP32/MCU receives more data than it can handle it can happen that the frame parser gets out of sync and stops parsing any new commands. 

This fix is aimed to prevent this behavior and restore the ability of the frame parser to keep parsing new frames and discarding the corrupt ones.

The funny thing is that you implemented it correctly on the RPi side but somehow it slipped from the MCU side. 