### PR TITLE
Frame lenght check and buffer overWrite prevention

### DIFF
--- a/SerialCom/ESP32/SerialCom.ino
+++ b/SerialCom/ESP32/SerialCom.ino
@@ -67,6 +67,7 @@ byte g_ReceiverStatus = RCV_ST_IDLE;
 byte g_xorValue = 0x00;
 byte g_Checksum = 0;
 int  g_DataLength = 0;
+int  g_DataLengthFixed = 0;
 int  g_BufferIndex = 0;
 
 bool g_AdcEnabled = false;
@@ -137,6 +138,7 @@ void loop()
                 case RCV_ST_DATA_LENGTH:
                 {
                     g_DataLength = receivedByte;
+                    g_DataLengthFixed = g_DataLength;
                     if(g_DataLength > 0)
                     {
                         g_InputBuffer[g_BufferIndex++] = receivedByte;
@@ -158,7 +160,7 @@ void loop()
     
                 case RCV_ST_CHECKSUM:
                 {
-                    if(receivedByte == g_Checksum)
+                    if(receivedByte == g_Checksum && g_BufferIndex == (g_DataLengthFixed + FRAME_NUM_EXTRA_BYTES -1))
                     {   
                         g_ReceiverStatus = RCV_ST_IDLE;
                         g_InputBuffer[g_BufferIndex++] = receivedByte;

--- a/SerialCom/QtRaspberry/frame.cpp
+++ b/SerialCom/QtRaspberry/frame.cpp
@@ -106,6 +106,13 @@ quint8  Frame::GetDataLength()
     return rv;
 }
 
+quint8  Frame::GetBufferLength()
+{
+    quint8 rv = m_buffer.length();
+    return rv;
+}
+
+
 quint8 Frame::GetUByte()
 {
     quint8 rv = 0;

--- a/SerialCom/QtRaspberry/frame.h
+++ b/SerialCom/QtRaspberry/frame.h
@@ -54,6 +54,7 @@ public:
     void    Clear();
     void    AddByte(quint8 data);
     QByteArray GetBuffer();
+    quint8  GetBufferLength();
 
 signals:
 

--- a/SerialCom/QtRaspberry/frameprocessor.cpp
+++ b/SerialCom/QtRaspberry/frameprocessor.cpp
@@ -29,7 +29,9 @@ void FrameProcessor::FrameIncoming(Frame *frame)
                 emit changedAdc(frame->GetUInt16());
             } break;
         }
+        frame->deleteLater();
     }
+
 }
 
 void FrameProcessor::setPwm(quint8 color, quint8 value)

--- a/SerialCom/QtRaspberry/frameprocessor.cpp
+++ b/SerialCom/QtRaspberry/frameprocessor.cpp
@@ -29,7 +29,7 @@ void FrameProcessor::FrameIncoming(Frame *frame)
                 emit changedAdc(frame->GetUInt16());
             } break;
         }
-        frame->deleteLater();
+        delete frame;
     }
 
 }

--- a/SerialCom/QtRaspberry/serialworker.cpp
+++ b/SerialCom/QtRaspberry/serialworker.cpp
@@ -52,6 +52,7 @@ void SerialWorker::doWork()
     Frame *m_inFrame = nullptr;
     quint8 checksum = 0, xored = 0x00;
     int dataLength = 0;
+    int maxdataLength = 10;
 
     // Serial Port Initialization
     m_Serial = new QSerialPort();
@@ -83,7 +84,7 @@ void SerialWorker::doWork()
             {
                 QByteArray receivedData = m_Serial->readAll();
 
-                while(receivedData.count() > 0)
+                while(receivedData.count() > 0 && receivedData.count() < maxdataLength )
                 {
                     inByte = quint8(receivedData[0]);
                     receivedData.remove(0,1);

--- a/SerialCom/QtRaspberry/serialworker.cpp
+++ b/SerialCom/QtRaspberry/serialworker.cpp
@@ -103,10 +103,7 @@ void SerialWorker::doWork()
                                 {
                                     if(inByte == Frame::FRAME_START)
                                     {
-                                        if (m_inFrame == nullptr)
-                                            m_inFrame = new Frame();
-                                        else
-                                            m_inFrame->Clear();
+                                        m_inFrame = new Frame();
                                         m_inFrame->AddByte(inByte);
                                         checksum = inByte;
                                         receiverStatus = RCV_ST_CMD;

--- a/SerialCom/QtRaspberry/serialworker.cpp
+++ b/SerialCom/QtRaspberry/serialworker.cpp
@@ -140,7 +140,7 @@ void SerialWorker::doWork()
 
                             case RCV_ST_CHECKSUM:
                                 {
-                                    if (inByte == checksum)
+                                    if (inByte == checksum && m_inFrame->GetBufferLength() == (dataLength + m_inFrame->FRAME_NUM_EXTRA_BYTES -1))
                                     {
                                         receiverStatus = RCV_ST_IDLE;
                                         m_inFrame->AddByte(checksum);
@@ -149,7 +149,6 @@ void SerialWorker::doWork()
                                     else
                                     {
                                         receiverStatus = RCV_ST_IDLE;
-                                        m_inFrame->Clear();
                                         delete m_inFrame;
                                     }
                                 } break;

--- a/SerialCom/QtRaspberry/serialworker.cpp
+++ b/SerialCom/QtRaspberry/serialworker.cpp
@@ -52,7 +52,6 @@ void SerialWorker::doWork()
     Frame *m_inFrame = nullptr;
     quint8 checksum = 0, xored = 0x00;
     int dataLength = 0;
-    int maxdataLength = 10;
 
     // Serial Port Initialization
     m_Serial = new QSerialPort();
@@ -84,7 +83,7 @@ void SerialWorker::doWork()
             {
                 QByteArray receivedData = m_Serial->readAll();
 
-                while(receivedData.count() > 0 && receivedData.count() < maxdataLength )
+                while(receivedData.count() > 0)
                 {
                     inByte = quint8(receivedData[0]);
                     receivedData.remove(0,1);


### PR DESCRIPTION
Two major improvements:

- Check if the frame is the right lenght before being accepted by the MCU or the RPI

-  Fixed a bug in which the RPI side received Frame buffer can be overwritten and cause major problems if the read of a new frame happens before finishing processing the previous. That can lead to unexpected crashes of the Qt app. 